### PR TITLE
rspec syntax

### DIFF
--- a/spec/questions_spec.rb
+++ b/spec/questions_spec.rb
@@ -170,8 +170,8 @@ describe 'the Friday test :)' do
     a = check_a_string_for_special_characters 'ABCdef123'
     b = check_a_string_for_special_characters 'ABC@def123!'
 
-    expect(a).to be_false
-    expect(b).to be_true
+    expect(a).to be false
+    expect(b).to be true
   end
 
   it 'get_upper_limit_of' do
@@ -183,8 +183,8 @@ describe 'the Friday test :)' do
     a = is_a_3_dot_range? 1..20
     b = is_a_3_dot_range? 1...20
 
-    expect(a).to be_false
-    expect(b).to be_true
+    expect(a).to be false
+    expect(b).to be true
   end
 
   it 'square_root_of' do
@@ -207,8 +207,8 @@ describe 'the Friday test :)' do
     a = is_a_2014_bank_holiday?(Time.new(2014, 8, 25))
     b = is_a_2014_bank_holiday?(Time.new(2014, 8, 26))
 
-    expect(a).to be_true
-    expect(b).to be_false
+    expect(a).to be true
+    expect(b).to be false
   end
 
   it 'your_birthday_is_on_a_friday_in_the_year' do


### PR DESCRIPTION
'to be_false' and 'to be_true' are deprecated in the latest version of rspec -- has to be 'to be false' and 'to be true'
